### PR TITLE
Adding angular lazy module for estimations

### DIFF
--- a/webapp/src/app/app-routing.module.ts
+++ b/webapp/src/app/app-routing.module.ts
@@ -3,11 +3,15 @@ import { Routes, RouterModule } from '@angular/router';
 
 
 const routes: Routes = [
+  {
+    path: 'estimation', loadChildren: () => import('./estimator/estimator.module')
+      .then(m => m.EstimatorModule)
+  }
 
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, { relativeLinkResolution: 'legacy' })],
+  imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/webapp/src/app/app.module.ts
+++ b/webapp/src/app/app.module.ts
@@ -2,11 +2,11 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule, Injectable } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-
-
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { HomeModule } from './home/home.module';
+import { SharedModule } from './shared/shared.module';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { AccountModule } from './account/account.module';
 import { AuthenticationInterceptor } from './authentication-interceptor';
@@ -22,8 +22,10 @@ import { AuthenticationInterceptor } from './authentication-interceptor';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     HomeModule,
+    SharedModule,
     AccountModule,
     AppRoutingModule,
     NgbModule

--- a/webapp/src/app/estimator/estimator-routing.module.ts
+++ b/webapp/src/app/estimator/estimator-routing.module.ts
@@ -6,11 +6,11 @@ import { AuthGuard } from '@app/auth.guard';
 
 const estimatorRoutes: Routes = [
   {
-    path: 'estimation/search',
+    path: 'search',
     component: SearchComponent, canActivate: [AuthGuard]
   },
   {
-    path: 'estimation/project/:id',
+    path: 'project/:id',
     component: ProposalComponent, canActivate: [AuthGuard]
   }
 ];

--- a/webapp/src/app/estimator/estimator.module.ts
+++ b/webapp/src/app/estimator/estimator.module.ts
@@ -2,15 +2,14 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SharedModule } from '../shared/shared.module';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EstimatorRoutingModule } from './estimator-routing.module';
 import { SearchComponent } from './search/search.component';
 import { ProposalComponent } from './proposal/proposal.component';
 import { TableModule } from 'primeng/table';
 import { TreeTableModule } from 'primeng/treetable';
-import {PanelModule} from 'primeng/panel'
-import {InputTextModule} from 'primeng/inputtext';
-import {ButtonModule} from 'primeng/button';
+import { PanelModule } from 'primeng/panel'
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonModule } from 'primeng/button';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 
@@ -20,7 +19,6 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
   declarations: [SearchComponent, ProposalComponent],
   imports: [
     CommonModule,
-    BrowserAnimationsModule,
     FormsModule,
     SharedModule,
     EstimatorRoutingModule,

--- a/webapp/src/app/home/home.module.ts
+++ b/webapp/src/app/home/home.module.ts
@@ -3,14 +3,13 @@ import { CommonModule } from '@angular/common';
 
 import { HomeRoutingModule } from './home-routing.module';
 import { HomeComponent } from './home.component';
-import { EstimatorModule } from '../estimator/estimator.module';
+
 
 
 @NgModule({
   declarations: [HomeComponent],
   imports: [
     CommonModule,
-    EstimatorModule,
     HomeRoutingModule
   ]
 })


### PR DESCRIPTION
Why?
Single Page Applications can get really big fast in a real world scenarios? We need to be able to load only the major sections that a user may be interested in.  Also allow for the Initial site to load faster without any additional delay.

How?
Refactor based on https://angular.io/guide/lazy-loading-ngmodules
